### PR TITLE
Fix typo in broker.md

### DIFF
--- a/patterns/broker.md
+++ b/patterns/broker.md
@@ -1,4 +1,4 @@
 Name:     Broker
 Scope:    Application Level Facility
-Summary:  A process can broken the sending of messages from publishers
+Summary:  A process can broker the sending of messages from publishers
           to subscribers.


### PR DESCRIPTION
Change "broken" to "broker".
