### PR TITLE
`site()` input param destructed not properly, fixed

### DIFF
--- a/index.erl
+++ b/index.erl
@@ -8,7 +8,7 @@ data(_) ->
       methodology    => {markdown, "METHODOLOGY.md"},
       patterns       => {markdown, "patterns/*.md"}}.
 
-site(Data) ->
+site([Data]) ->
     #{"site/index.html"        => {template, "template/index.html"},
       "site/methodology.html"  => {template, "template/methodology.html"},
       "site/patterns.html"     => {template, "template/patterns.html"},


### PR DESCRIPTION
Got this error while `make`'ing the project:

```
[··· ~/Documents/erlang-patterns/erlang-patterns ↵]
make
rm -f site/*.html
lpad-gen
=== ERROR ===
{{required_value,patterns},
 [{plist,value,2,[{file,"src/plist.erl"},{line,27}]},
  {index,site,1,
         [{file,"/Users/zarkone/Documents/erlang-patterns/erlang-patterns/index.erl"},
          {line,18}]},
  {lpad,generator_specs,2,[{file,"src/lpad.erl"},{line,191}]},
  {lpad,process_index,2,[{file,"src/lpad.erl"},{line,103}]},
  {lpad,run,2,[{file,"src/lpad.erl"},{line,37}]},
  {erl_eval,local_func,5,[{file,"erl_eval.erl"},{line,556}]},
  {erl_eval,expr_list,6,[{file,"erl_eval.erl"},{line,877}]},
  {erl_eval,local_func,5,[{file,"erl_eval.erl"},{line,551}]}]}

make: *** [gen] Error 1
```